### PR TITLE
Stop the fact from exploding on LNXSYSTM path

### DIFF
--- a/lib/facter/disks.rb
+++ b/lib/facter/disks.rb
@@ -60,9 +60,13 @@ class BlockInfo
     elsif parts.first == "platform" then
       Facter.debug("device #{device} is on a pseudo bus, ignoring")
     else
-      raise "non-pci device #{device}" unless parts.first.start_with?("pci")
+      raise "non-pci device #{device}" unless parts.first =~ /^(pci|LNXSYSTM)/
       driverlink = ["", "sys", "devices", parts.shift]
-      driverlink.concat(parts.take_while { |p| p.match(/^[0-9a-f:.]+$/i) })
+      if driverlink.last.start_with?("pci")
+        driverlink.concat(parts.take_while { |p| p.match(/^[0-9a-f:.]+$/i) })
+      else
+        driverlink.concat(parts.take_while { |p| not p.match(/^host[0-9]/) })
+      end
       driverlink << "driver"
       driverpath = File.readlink(driverlink.join("/"))
       raise "no driver for #{device}" unless driverpath


### PR DESCRIPTION
This makes the block_devices fact reappear on Microsoft Azure (and presumably Hyper-V).

Might also fix it for others.